### PR TITLE
run_idを追加できるように修正

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -62,6 +62,7 @@ async def on_run(data):
         clients = int(data["clients"])
         duration = int(data["time"])
         job_id = data.get("jobId") or str(uuid.uuid4())
+        run_id = data.get("runId") or f"run_{job_id}"
     except (KeyError, ValueError):
         return logging.error("invalid run payload: %s", data)
 
@@ -101,6 +102,7 @@ async def on_run(data):
                 "jobId":    job_id,
                 "tps":      tps,
                 "latency_ms": lat,
+                "runId": run_id,
             })
 
     await proc.wait()
@@ -110,6 +112,7 @@ async def on_run(data):
         "jobId":      job_id,
         "returncode": proc.returncode,
         "stdout":     "\n".join(stdout_lines),
+        "runId":      run_id,
     })
     logging.info("job=%s end code=%s", job_id, proc.returncode)
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "bullmq": "^5.25.0",
+        "dayjs": "^1.11.13",
         "dotenv": "^16.5.0",
         "express": "^4.19.0",
         "ioredis": "^5.4.2",
@@ -299,6 +300,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "bullmq": "^5.25.0",
+    "dayjs": "^1.11.13",
     "dotenv": "^16.5.0",
     "express": "^4.19.0",
     "ioredis": "^5.4.2",

--- a/backend/src/routes/scenario.js
+++ b/backend/src/routes/scenario.js
@@ -3,13 +3,15 @@ import { randomUUID } from "node:crypto";
 import pg from "pg";
 import { getIO } from "../io.js";
 import queue from "../queues/pgbench.js";
+import dayjs from "dayjs";
 
 const pgPool = new pg.Pool({ connectionString: process.env.PG_URL });
 const router = Router();
 
 router.post("/", async (req, res, next) => {
   try {
-    const { agentIds, clients, time } = req.body;
+    const { agentIds, clients, time, runId } = req.body;
+    const run_id = runId?.trim() || `run_${dayjs().format("YYYYMMDD_HHmmss")}`;
 
     // ── バリデーション ──────────────────────
     if (
@@ -32,15 +34,15 @@ router.post("/", async (req, res, next) => {
 
       // bench_result へ仮行を INSERT
       await pgPool.query(
-        `INSERT INTO bench_result(agent_id, job_id)
-         VALUES ($1,$2) ON CONFLICT DO NOTHING`,
-        [id, jobId]
+        `INSERT INTO bench_result(agent_id, job_id, run_id)
+         VALUES ($1,$2,$3) ON CONFLICT DO NOTHING`,
+        [id, jobId, run_id]
       );
 
       // Socket.IO へ
       for (const [, sock] of io.of("/").sockets) {
         if (sock.data.agentId === id) {
-          sock.emit("run", { jobId, clients, time });
+          sock.emit("run", { jobId, runId: run_id, clients, time });
           break;
         }
       }
@@ -55,6 +57,7 @@ router.post("/", async (req, res, next) => {
     // ── ★ レスポンスはここで 1 回だけ ─────
     return res.status(202).json({
       queued: true,
+      runId: run_id,
       jobs,
     });
   } catch (err) {

--- a/backend/src/ws/progress-handler.js
+++ b/backend/src/ws/progress-handler.js
@@ -13,8 +13,18 @@ await pool.query(`
     job_id     uuid,
     tps        numeric,
     latency_ms numeric,
-    ts         timestamptz default now()
-  );`);
+    ts         timestamptz default now(),
+    run_id     text
+  );
+  
+    ALTER TABLE bench_progress
+    ADD COLUMN IF NOT EXISTS agent_id   text,
+    ADD COLUMN IF NOT EXISTS job_id     uuid,
+    ADD COLUMN IF NOT EXISTS tps        numeric,
+    ADD COLUMN IF NOT EXISTS latency_ms numeric,
+    ADD COLUMN IF NOT EXISTS ts         timestamptz DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS run_id     text;
+  `);
 
 console.log("bench_progress table ready");
 
@@ -23,9 +33,9 @@ io.on("connection", (socket) => {
   socket.on("progress", async (row) => {
     try {
       await pool.query(
-        `INSERT INTO bench_progress(agent_id, job_id, tps, latency_ms)
-         VALUES ($1,$2,$3,$4)`,
-        [row.agentId, row.jobId, row.tps, row.latency_ms]
+        `INSERT INTO bench_progress(agent_id, job_id, tps, latency_ms, run_id)
+         VALUES ($1,$2,$3,$4,$5)`,
+        [row.agentId, row.jobId, row.tps, row.latency_ms, row.runId]
       );
     } catch (e) {
       console.error("progress insert error:", e);

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.1.tgz",
-      "integrity": "sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.2.tgz",
+      "integrity": "sha512-OfXHZPppddivUJnqyKoi5YVeHRkkNE2zUFT2gbpKxp/JZCFYEYubnMg+gOp6lWfasPrTS+KPosKqdI+ELYVDtg==",
       "cpu": [
         "arm64"
       ],
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.1.tgz",
-      "integrity": "sha512-VfuYgG2r8BpYiOUN+BfYeFo69nP/MIwAtSJ7/Zpxc5QF3KS22z8Pvg3FkrSFJBPNQ7mmcUcYQFBmEQp7eu1F8Q==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.2.tgz",
+      "integrity": "sha512-dYvWqmjU9VxqXmjEtjmvHnGqF8GrVjM2Epj9rJ6BUIXvk8slvNDJbhGFvIoXzkDhrJC2jUxNLz/GUjjvSzfw+g==",
       "cpu": [
         "x64"
       ],
@@ -217,9 +217,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.1.tgz",
-      "integrity": "sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.2.tgz",
+      "integrity": "sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==",
       "cpu": [
         "arm"
       ],
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.1.tgz",
-      "integrity": "sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.2.tgz",
+      "integrity": "sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==",
       "cpu": [
         "arm64"
       ],
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.1.tgz",
-      "integrity": "sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.2.tgz",
+      "integrity": "sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==",
       "cpu": [
         "s390x"
       ],
@@ -283,9 +283,9 @@
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.1.tgz",
-      "integrity": "sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.2.tgz",
+      "integrity": "sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==",
       "cpu": [
         "x64"
       ],
@@ -305,9 +305,9 @@
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.1.tgz",
-      "integrity": "sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.2.tgz",
+      "integrity": "sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==",
       "cpu": [
         "arm64"
       ],
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.1.tgz",
-      "integrity": "sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.2.tgz",
+      "integrity": "sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==",
       "cpu": [
         "x64"
       ],
@@ -349,16 +349,16 @@
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.1.tgz",
-      "integrity": "sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.2.tgz",
+      "integrity": "sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.4.0"
+        "@emnapi/runtime": "^1.4.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -367,10 +367,29 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.2.tgz",
+      "integrity": "sha512-cfP/r9FdS63VA5k0xiqaNaEoGxBg9k7uE+RQGzuK9fHt7jib4zAVVseR9LsE4gJcNWgT6APKMNnCcnyOtmSEUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.1.tgz",
-      "integrity": "sha512-WKf/NAZITnonBf3U1LfdjoMgNO5JYRSlhovhRhMxXVdvWYveM4kM3L8m35onYIdh75cOMCo1BexgVQcCDzyoWw==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.2.tgz",
+      "integrity": "sha512-QLjGGvAbj0X/FXl8n1WbtQ6iVBpWU7JO94u/P2M4a8CFYsvQi4GW2mRy/JqkRx0qpBzaOdKJKw8uc930EX2AHw==",
       "cpu": [
         "ia32"
       ],
@@ -387,9 +406,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.1.tgz",
-      "integrity": "sha512-hw1iIAHpNE8q3uMIRCgGOeDoz9KtFNarFLQclLxr/LK1VBkj8nby18RjFvr6aP7USRYAjTZW6yisnBWMX571Tw==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.2.tgz",
+      "integrity": "sha512-aUdT6zEYtDKCaxkofmmJDJYGCf0+pJg3eU9/oBuqvEeoB9dKI6ZLc/1iLJCTuJQDO4ptntAlkUmHgGjyuobZbw==",
       "cpu": [
         "x64"
       ],
@@ -852,16 +871,16 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.1.tgz",
-      "integrity": "sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.2.tgz",
+      "integrity": "sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.7.1"
+        "detect-libc": "^2.0.4",
+        "semver": "^7.7.2"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -870,8 +889,8 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.1",
-        "@img/sharp-darwin-x64": "0.34.1",
+        "@img/sharp-darwin-arm64": "0.34.2",
+        "@img/sharp-darwin-x64": "0.34.2",
         "@img/sharp-libvips-darwin-arm64": "1.1.0",
         "@img/sharp-libvips-darwin-x64": "1.1.0",
         "@img/sharp-libvips-linux-arm": "1.1.0",
@@ -881,15 +900,16 @@
         "@img/sharp-libvips-linux-x64": "1.1.0",
         "@img/sharp-libvips-linuxmusl-arm64": "1.1.0",
         "@img/sharp-libvips-linuxmusl-x64": "1.1.0",
-        "@img/sharp-linux-arm": "0.34.1",
-        "@img/sharp-linux-arm64": "0.34.1",
-        "@img/sharp-linux-s390x": "0.34.1",
-        "@img/sharp-linux-x64": "0.34.1",
-        "@img/sharp-linuxmusl-arm64": "0.34.1",
-        "@img/sharp-linuxmusl-x64": "0.34.1",
-        "@img/sharp-wasm32": "0.34.1",
-        "@img/sharp-win32-ia32": "0.34.1",
-        "@img/sharp-win32-x64": "0.34.1"
+        "@img/sharp-linux-arm": "0.34.2",
+        "@img/sharp-linux-arm64": "0.34.2",
+        "@img/sharp-linux-s390x": "0.34.2",
+        "@img/sharp-linux-x64": "0.34.2",
+        "@img/sharp-linuxmusl-arm64": "0.34.2",
+        "@img/sharp-linuxmusl-x64": "0.34.2",
+        "@img/sharp-wasm32": "0.34.2",
+        "@img/sharp-win32-arm64": "0.34.2",
+        "@img/sharp-win32-ia32": "0.34.2",
+        "@img/sharp-win32-x64": "0.34.2"
       }
     },
     "node_modules/simple-swizzle": {

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -8,7 +8,8 @@ export default function Home() {
   const [selected, setSelected] = useState<string[]>([]);
   const [clients, setClients] = useState(10);
   const [time, setTime] = useState(60);
-  const [running, setRunning] = useState<JobMap>({}); // ★ 実行中ジョブ
+  const [running, setRunning] = useState<JobMap>({});
+  const [runIdInput, setRunIdInput] = useState("");
 
   /* Running */
   useEffect(() => {
@@ -29,10 +30,16 @@ export default function Home() {
     const res = await fetch("/api/scenario", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ agentIds: selected, clients, time }),
+      body: JSON.stringify({
+        agentIds: selected,
+        clients,
+        time,
+        runId: runIdInput.trim() || undefined,
+      }),
     });
     const { jobs } = await res.json(); // {agentId: jobId}
     setRunning((prev) => ({ ...prev, ...jobs }));
+    setRunIdInput("");
   }
 
   /* Stop */
@@ -55,6 +62,17 @@ export default function Home() {
       <h1 className="text-xl font-bold">pgbench Collector</h1>
 
       <AgentSelector selected={selected} onSelect={setSelected} />
+
+      <label className="block">
+        run id&nbsp;
+        <input
+          type="text"
+          className="border px-1 rounded w-52"
+          placeholder="任意ラベル (空 = 自動)"
+          value={runIdInput}
+          onChange={(e) => setRunIdInput(e.target.value)}
+        />
+      </label>
 
       <div className="space-x-4">
         <label>


### PR DESCRIPTION
# 目的

エージェントを同時同時に実行した場合、job_id だとユニークになっているため、例えばあるタイミングでエージェントAとエージェントBを同時に動かしたとき、エージェントAとエージェントCを同時に動かしたときなどの比較を行いたい場合のデータ取得多少不便である。

そこで任意で設定できる run_id を準備して登録できるようにする

## 変更点

- run_id を bench_result および bench_progress に追加する
- frontend 側に run_id を入力できる欄を追加し、入力がない場合は `run_[yyyymmdd_hhmmss]` が入るようにする
- テーブルへの項目追加のため、各 handler に ALTER TABLE を用意し、実行時に列追加をするようにする